### PR TITLE
Stub for doctest.testmod()

### DIFF
--- a/src/lib/doctest.py
+++ b/src/lib/doctest.py
@@ -1,1 +1,9 @@
-raise NotImplementedError("doctest is not yet implemented in Skulpt")
+"""Stub implementation for Runestone Interactive books so students' doctests don't fail."""
+
+message = "The doctest module is not yet implemented by Skulpt. Please run your doctests in your own IDE!"
+
+def testmod():
+  print(message)
+
+if __name__ == "__main__":
+  print(message)


### PR DESCRIPTION
Just enough so "import doctest; doctest.testmod()" in student programs that rely on the doctest module doesn't fail. Instead, an error message reminding the user to run those doctests in an IDE is printed, and the doctests are "silently" ignored.