### PR TITLE
Image setDelay bugfix

### DIFF
--- a/src/lib/image.js
+++ b/src/lib/image.js
@@ -206,13 +206,11 @@ $builtinmodule = function (name) {
                 type: "Sk.promise",
                 promise: new Promise(function (resolve, reject) {
                     self.updateCount++;
-                    if ((self.updateCount % self.updateInterval) === 0) {
+                    if ((self.updateCount % self.updateInterval) === 0 ||
+                        (self.updateCount === self.width * self.height)) {
                         if (self.lastx + self.updateInterval >= self.width) {
                             self.lastCtx.putImageData(self.imagedata, self.lastUlx, self.lastUly,
-                                0, self.lasty, self.width, 2);
-                        } else if (self.lasty + self.updateInterval >= self.height) {
-                            self.lastCtx.putImageData(self.imagedata, self.lastUlx, self.lastUly,
-                                self.lastx, 0, 2, self.height);
+                                0, self.lasty, self.width, Math.ceil((self.lastx + self.updateInterval) / self.width));
                         } else {
                             self.lastCtx.putImageData(self.imagedata, self.lastUlx, self.lastUly,
                                 Math.min(x, self.lastx),

--- a/src/lib/image.js
+++ b/src/lib/image.js
@@ -208,18 +208,7 @@ $builtinmodule = function (name) {
                     self.updateCount++;
                     if ((self.updateCount % self.updateInterval) === 0 ||
                         (self.updateCount === self.width * self.height)) {
-                        if (self.lastx + self.updateInterval >= self.width) {
-                            self.lastCtx.putImageData(self.imagedata, self.lastUlx, self.lastUly,
-                                0, self.lasty, self.width, Math.ceil((self.lastx + self.updateInterval) / self.width));
-                        } else {
-                            self.lastCtx.putImageData(self.imagedata, self.lastUlx, self.lastUly,
-                                Math.min(x, self.lastx),
-                                Math.min(y, self.lasty),
-                                Math.max(Math.abs(x - self.lastx), 1),
-                                Math.max(Math.abs(y - self.lasty), 1));
-                        }
-                        self.lastx = x;
-                        self.lasty = y;
+                            self.lastCtx.putImageData(self.imagedata, 0, 0);
                         if (self.delay > 0) {
                             window.setTimeout(resolve, self.delay);
                         } else {


### PR DESCRIPTION
Existing image code has an assumption that no more than 2 lines will need to be redrawn.
If `updateInterval > 2 * width `that will not be the case and the image ends up with banding.
This allows for an arbitrary number of lines to be redrawn at each repaint.

It also removes what I believe to be an extraneous condition:
`else if (self.lasty + self.updateInterval >= self.height)`
From what I can see, either we are in a row and going to stay in that row (the else), or we are going to finish a row and possibly wrap to a new row (first if).