### PR TITLE
input() should not preserve any newline from sys.stdin.readline()

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -711,7 +711,8 @@ Sk.builtin.raw_input = function (prompt) {
                     return Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdout"]["write"], [sys["$d"]["stdout"], new Sk.builtin.str(lprompt)]);
                 },
                 function () {
-                    return Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdin"]["readline"], [sys["$d"]["stdin"]]);
+                    const s = Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdin"]["readline"], [sys["$d"]["stdin"]]);
+                    return new Sk.builtin.str(s.$jsstr().replace(/[\r\n]+$/, ""));
                 }
             );
         }


### PR DESCRIPTION
When input() ends up reading from a file-like sys.stdin (instead of using inputfunc), it is currently including any newline characters naturally emitted by `file.readline`. This should not be the case.